### PR TITLE
Change static path to look into dist

### DIFF
--- a/app.js
+++ b/app.js
@@ -16,9 +16,9 @@ app.use(bodyParser.urlencoded({ extended: true }))
 app.use('/api', AppRouter)
 
 if (process.env.NODE_ENV === 'production') {
-  app.use(express.static(path.join(__dirname, 'client/build')))
+  app.use(express.static(path.join(__dirname, 'client/dist')))
   app.get('*', (req, res) => {
-    res.sendFile(path.join(`${__dirname}/client/build/index.html`))
+    res.sendFile(path.join(`${__dirname}/client/dist/index.html`))
   })
 }
 


### PR DESCRIPTION
By watching this [video](https://www.youtube.com/watch?v=W-b9KGwVECs) I saw that his process to deploy a Vue app is a bit different from what we are doing here.
He's building, what Vue creates as `dist` folder, in the server side of the app under the name of `static`. 

Just to try I want to see if Heroku is at the moment not capable to find `dist` because we have declared the path as `build`.

If this step isn't working you can try to follow what he's doing.